### PR TITLE
Add some sort of backup to the mysql database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,13 +71,14 @@ RUN	systemd-tmpfiles --create zoneminder.conf && \
 
 FROM build4 as build5
 RUN	mv /root/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf && \
+	mv /root/bkp.sh /etc/cron.weekly/ && \
 	mkdir /etc/apache2/ssl/ && \
 	mkdir -p /var/lib/zmeventnotification/images && \
 	chown -R www-data:www-data /var/lib/zmeventnotification/ && \
 	chmod -R +x /etc/my_init.d/ && \
 	cp -p /etc/zm/zm.conf /root/zm.conf && \
 	echo "#!/bin/sh\n\n/usr/bin/zmaudit.pl -f" >> /etc/cron.weekly/zmaudit && \
-	chmod +x /etc/cron.weekly/zmaudit && \
+	chmod +x /etc/cron.weekly/* && \
 	cp /etc/apache2/ports.conf /etc/apache2/ports.conf.default && \
 	cp /etc/apache2/sites-enabled/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf.default
 

--- a/defaults/bkp.sh
+++ b/defaults/bkp.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-mdir -p /config/mysql-bkps/ &&  mysqldump -u root zm | gzip -c > /config/mysql-bkps/dump.$(date +%F).dump.gz
+mkdir -p /config/mysql-bkps/ &&  mysqldump -u root zm | gzip -c > /config/mysql-bkps/dump.$(date +%F).dump.gz

--- a/defaults/bkp.sh
+++ b/defaults/bkp.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+mdir -p /config/mysql-bkps/ &&  mysqldump -u root zm | gzip -c > /config/mysql-bkps/dump.$(date +%F).dump.gz

--- a/defaults/bkp.sh
+++ b/defaults/bkp.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
-mkdir -p /config/mysql-bkps/ &&  mysqldump -u root zm | gzip -c > /config/mysql-bkps/dump.$(date +%F).dump.gz
+[ -f /etc/.do_mysql_backups ] || exit 0
+mkdir -p /config/mysql-bkps/
+find /config/mysql-bkps  -type f -ctime +60 -delete # keep backups for 2 months
+mysqldump -u root zm | nice -n19 bzip2 -c > /config/mysql-bkps/dump.$(date +%F).dump.bz2

--- a/init/01_enable_weekly_backup.sh
+++ b/init/01_enable_weekly_backup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+[ "$ENABLE_WEEKLY_MYSQL_BACKUPS" == "true" ] && touch /etc/.do_mysql_backups


### PR DESCRIPTION
I had problems of  unrecoverable database corruption a few times after power outage. This change adds a simple script that runs weekly and do database dumps to the /config/mysql-bkps directory.